### PR TITLE
tighten metrics API

### DIFF
--- a/R/log-dir.R
+++ b/R/log-dir.R
@@ -70,12 +70,14 @@ eval_log_write <- function(x = eval_log(), dir = vitals_log_dir()) {
     dir.create(dir, showWarnings = FALSE, recursive = TRUE)
   }
 
+  path <- file.path(dir, eval_log_filename(x))
   jsonlite::write_json(
     x = structure(x, class = "list"),
-    path = file.path(dir, eval_log_filename(x)),
+    path = path,
     auto_unbox = TRUE,
     pretty = TRUE
   )
+  path
 }
 
 # eval log files are quite relational, where the `samples` and `logging` fields

--- a/R/translate.R
+++ b/R/translate.R
@@ -214,34 +214,3 @@ translate_to_eval_scorers <- function(name) {
     metadata = c()
   ))
 }
-
-# validating log files (for dev use only) --------------------------------------
-# invokes Inspect's pydantic models on an eval log file so that
-# we can ensure we're writing files that are compatible with the
-# viewer.
-validate_log <- function(x) {
-  if (!file.exists(x)) {
-    cli::cli_abort("Log file {x} does not exist.")
-  }
-  
-  py_script <- system.file("test/validate_log.py", package = "vitals")
-  
-  if (!file.exists(py_script)) {
-    cli::cli_abort("Python validation script {py_script} not found.")
-  }
-  
-  result <- system2(
-    "python",
-    args = c(py_script, x),
-    stdout = TRUE,
-    stderr = TRUE
-  )
-  status <- attr(result, "status")
-  
-  if (!is.null(status) && status > 0) {
-    cli::cli_abort("{result}")
-  }
-  
-  cli::cli_alert_success("Log file validated successfully")
-  return(invisible(NULL))
-}

--- a/man/Task.Rd
+++ b/man/Task.Rd
@@ -17,8 +17,9 @@ comparisons (like \code{\link[=detect_match]{detect_match()}}), model grading (l
 }
 
 \strong{The usual flow of LLM evaluation with Tasks calls \verb{$new()} and then \verb{$eval()}.}
-\verb{$eval()} just calls \verb{$solve()}, \verb{$score()}, \verb{$log()}, and \verb{$view()} in order.
-The remaining methods are generally only recommended for expert use.
+\verb{$eval()} just calls \verb{$solve()}, \verb{$score()}, \verb{$measure()}, \verb{$log()},
+and \verb{$view()} in order. The remaining methods are generally only
+recommended for expert use.
 }
 \examples{
 if (!identical(Sys.getenv("ANTHROPIC_API_KEY"), "")) {
@@ -58,9 +59,9 @@ to \code{vitals_log_dir()}.}
 \code{epochs} may duplicate rows, and the solver and scorer will append
 columns to this data.}
 
-\item{\code{metric}}{A named list of metric functions to apply to scoring results.}
-
-\item{\code{metrics}}{The metrics calculated in \code{metric()}.}
+\item{\code{metrics}}{A named vector of metric values resulting from \verb{$measure()}
+(called inside of \verb{$eval()}). Will be \code{NULL} if metrics have yet to
+be applied.}
 }
 \if{html}{\out{</div>}}
 }
@@ -71,10 +72,12 @@ columns to this data.}
 \item \href{#method-Task-eval}{\code{Task$eval()}}
 \item \href{#method-Task-solve}{\code{Task$solve()}}
 \item \href{#method-Task-score}{\code{Task$score()}}
+\item \href{#method-Task-measure}{\code{Task$measure()}}
 \item \href{#method-Task-log}{\code{Task$log()}}
 \item \href{#method-Task-view}{\code{Task$view()}}
 \item \href{#method-Task-set_solver}{\code{Task$set_solver()}}
 \item \href{#method-Task-set_scorer}{\code{Task$set_scorer()}}
+\item \href{#method-Task-set_metrics}{\code{Task$set_metrics()}}
 \item \href{#method-Task-clone}{\code{Task$clone()}}
 }
 }
@@ -89,7 +92,7 @@ calling this method and then \verb{$eval()} on the resulting object.
   dataset,
   solver,
   scorer,
-  metric = NULL,
+  metrics = NULL,
   epochs = NULL,
   name = deparse(substitute(dataset)),
   dir = vitals_log_dir()
@@ -147,7 +150,7 @@ Scorers will probably make use of \code{samples$input}, \code{samples$target}, a
 \code{samples$result} specifically. See \link[=scorer_model]{model-based scoring}
 for examples.}
 
-\item{\code{metric}}{A metric summarizing the results from the scorer.}
+\item{\code{metrics}}{A metric summarizing the results from the scorer.}
 
 \item{\code{epochs}}{The number of times to repeat each sample. Evaluate each sample
 multiple times to better quantify variation. Optional, defaults to \code{1L}.
@@ -240,6 +243,16 @@ its results.
 \subsection{Returns}{
 The Task object (invisibly)
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Task-measure"></a>}}
+\if{latex}{\out{\hypertarget{method-Task-measure}{}}}
+\subsection{Method \code{measure()}}{
+Applies metrics to a scored Task.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Task$measure()}\if{html}{\out{</div>}}
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Task-log"></a>}}
@@ -357,6 +370,27 @@ for examples.}
 }
 \subsection{Returns}{
 The Task object (invisibly)
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Task-set_metrics"></a>}}
+\if{latex}{\out{\hypertarget{method-Task-set_metrics}{}}}
+\subsection{Method \code{set_metrics()}}{
+Set the metrics that will be applied in \verb{$measure()} (and thus \verb{$eval()}).
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Task$set_metrics(metrics)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{metrics}}{A named list of functions that take in a vector of scores
+(as in \code{task$samples$score}) and output a single numeric value.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The Task (invisibly)
 }
 }
 \if{html}{\out{<hr>}}

--- a/tests/testthat/_snaps/task.md
+++ b/tests/testthat/_snaps/task.md
@@ -80,6 +80,37 @@
       Warning:
       Clearing scores from previous scorer.
 
+# task errors informatively with bad metrics
+
+    Code
+      tsk <- Task$new(dataset = simple_addition, solver = generate(ellmer::chat_anthropic(
+        model = "claude-3-7-sonnet-latest")), scorer = function(...) {
+        list(score = factor(c("C", "C"), levels = c("I", "P", "C")))
+      }, metrics = function(scores) {
+        mean(scores == "C") * 100
+      })
+    Condition
+      Error in `initialize()`:
+      ! `metrics` must be a named list of functions or NULL, not a function
+
+---
+
+    Code
+      tsk$set_metrics(function(...) "boop bop")
+    Condition
+      Error:
+      ! `metrics` must be a named list of functions or NULL, not a function
+
+---
+
+    Code
+      tsk$set_metrics(list(bad_metric = function(scores) "this is not a numeric"))
+      tsk$eval()
+    Condition
+      Error in `measure()`:
+      ! Each metric function must return a single numeric value
+      `bad_metric()` returned a string
+
 # Task completeness is tracked and preserved
 
     Code

--- a/tests/testthat/helper-validate.R
+++ b/tests/testthat/helper-validate.R
@@ -1,0 +1,48 @@
+# validating log files (for dev use only) --------------------------------------
+# invokes Inspect's pydantic models on an eval log file so that
+# we can ensure we're writing files that are compatible with the
+# viewer.
+validate_log <- function(x) {
+  # TODO: each of these skips can probably just be evaluated once in a `local()`
+  skip_on_cran()
+
+  skip_if_not(
+    system2("python", "--version", stdout = FALSE, stderr = FALSE) == 0,
+    message = "Python is not available"
+  )
+    
+  skip_if_not(
+    system2("python", "-c 'import inspect_ai'", stdout = FALSE, stderr = FALSE) == 0,
+    message = "inspect_ai Python module is not available"
+  )
+    
+  skip_if_not(
+    system2("python", "-c 'import pydantic'", stdout = FALSE, stderr = FALSE) == 0,
+    message = "pydantic Python module is not available"
+  )
+
+  if (!file.exists(x)) {
+    cli::cli_abort("Log file {x} does not exist.")
+  }
+  
+  py_script <- system.file("test/validate_log.py", package = "vitals")
+  
+  if (!file.exists(py_script)) {
+    cli::cli_abort("Python validation script {py_script} not found.")
+  }
+  
+  result <- system2(
+    "python",
+    args = c(py_script, x),
+    stdout = TRUE,
+    stderr = TRUE
+  )
+  status <- attr(result, "status")
+  
+  if (!is.null(status) && status > 0) {
+    cli::cli_abort("{result}")
+  }
+  
+  cli::cli_alert_success("Log file validated successfully")
+  return(invisible(NULL))
+}

--- a/tests/testthat/test-translate.R
+++ b/tests/testthat/test-translate.R
@@ -1,20 +1,3 @@
-skip_on_cran()
-
-skip_if_not(
-  system2("python", "--version", stdout = FALSE, stderr = FALSE) == 0,
-  message = "Python is not available"
-)
-  
-skip_if_not(
-  system2("python", "-c 'import inspect_ai'", stdout = FALSE, stderr = FALSE) == 0,
-  message = "inspect_ai Python module is not available"
-)
-  
-skip_if_not(
-  system2("python", "-c 'import pydantic'", stdout = FALSE, stderr = FALSE) == 0,
-  message = "pydantic Python module is not available"
-)
-
 test_that("validate_log fails when log file is nonsense", {
   # use a file name that "looks like" it could be a real Inspect log so that
   # Inspect tries to read it
@@ -160,7 +143,10 @@ test_that("vitals writes valid eval logs (solver errors on tool call, claude)", 
     solver = generate(ch),
     scorer = function(samples) {list(score = factor("C", levels = c("I", "C"), ordered = TRUE))}
   )
-  tsk$eval()
+
+  # a tool call will fail here and raise a warning; this is intentional.
+  # since raised from ellmer, we don't expect anything specific about it.
+  suppressWarnings(tsk$eval())
 
   log_file <- list.files(tmp_dir, full.names = TRUE)
   expect_gte(length(log_file), 1)


### PR DESCRIPTION
Closes #59.

Shares as much of its idioms with solvers and scorers as possible, but a little bit different because:

* There's one value for the whole eval rather than per-sample, so the result lives in a `metrics` slot rather than as a column in `samples`
* There's not a verb corresponding to `metrics` that's so clear as solver/solve and scorer/score, so I use metric/measure.

Also:

* `tsk_log()` now returns a path to the written eval log.
* `validate_log()` becomes a test helper rather than an exported function, and incorporates the needed skip conditions rather than having them be file-level; that way, we can validate logged output in every test that runs `$eval()`.

